### PR TITLE
Protect merge with transformer from nil/invalid values

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -56,6 +56,12 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 
 	if config.transformers != nil {
 		if fn := config.transformers.Transformer(dst.Type()); fn != nil {
+			if isEmptyValue(dst) {
+				if dst.CanSet() && !isEmptyValue(src) {
+					dst.Set(src)
+				}
+				return
+			}
 			err = fn(dst, src)
 			return
 		}

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,0 +1,50 @@
+package mergo
+
+import (
+	"reflect"
+	"testing"
+)
+
+type transformer struct {
+	m map[reflect.Type]func(dst, src reflect.Value) error
+}
+
+func (s *transformer) Transformer(t reflect.Type) func(dst, src reflect.Value) error {
+	if fn, ok := s.m[t]; ok {
+		return fn
+	}
+	return nil
+}
+
+type foo struct {
+	s   string
+	Bar *bar
+}
+
+type bar struct {
+	i int
+	s map[string]string
+}
+
+func TestMergeWithTransformerNilStruct(t *testing.T) {
+	a := foo{s: "foo"}
+	b := foo{Bar: &bar{i: 2, s: map[string]string{"foo": "bar"}}}
+	if err := Merge(&a, &b, WithOverride, WithTransformers(&transformer{
+		m: map[reflect.Type]func(dst, src reflect.Value) error{
+			reflect.TypeOf(&bar{}): func(dst, src reflect.Value) error {
+				// Do sthg with Elem
+				t.Log(dst.Elem().FieldByName("i"))
+				t.Log(src.Elem())
+				return nil
+			},
+		},
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if a.s != "foo" {
+		t.Fatalf("b not merged in properly: a.s.Value(%s) != expected(%s)", a.s, "foo")
+	}
+	if a.Bar == nil {
+		t.Fatalf("b not merged in properly: a.Bar shouldn't be nil")
+	}
+}

--- a/mergo.go
+++ b/mergo.go
@@ -47,6 +47,8 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Float() == 0
 	case reflect.Interface, reflect.Ptr, reflect.Func:
 		return v.IsNil()
+	case reflect.Invalid:
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
Merging with transformer might call some `reflect.Value` methods that
could panic if the value is `reflect.Invalid` (i.e. empty/nil/…).

This fix that by previously verifying values (dst and src) are not empty
before actually calling the transformer.

cc @imdario 

I did not take this case in action when writing the transformers. Adds a tests that fails on without that change 👼.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>