### PR TITLE
Fixing merging slices with `WithAppendSlice` and `WithOverride` options 

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -136,7 +136,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 					dst.SetMapIndex(key, dstSlice)
 				}
 			}
-			if dstElement.IsValid() && reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map {
+			if dstElement.IsValid() && !isEmptyValue(dstElement) && (reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map || reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Slice) {
 				continue
 			}
 

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -294,6 +294,7 @@ func TestSlice(t *testing.T) {
 	testSlice(t, nil, []int{1, 2, 3}, []int{1, 2, 3}, WithAppendSlice)
 	testSlice(t, []int{}, []int{1, 2, 3}, []int{1, 2, 3}, WithAppendSlice)
 	testSlice(t, []int{1}, []int{2, 3}, []int{1, 2, 3}, WithAppendSlice)
+	testSlice(t, []int{1}, []int{2, 3}, []int{1, 2, 3}, WithAppendSlice, WithOverride)
 	testSlice(t, []int{1}, []int{}, []int{1}, WithAppendSlice)
 	testSlice(t, []int{1}, nil, []int{1}, WithAppendSlice)
 }


### PR DESCRIPTION
From #95.