### PR TITLE
feature: Allow Map() to handle when a struct has pointer fields as "optional"

### DIFF
--- a/map.go
+++ b/map.go
@@ -95,6 +95,18 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, conf
 				}
 			}
 
+			// Handle case there the destination field is a pointer,
+			// commonly used to implement "optional" values.
+			if dstElement.Kind() == reflect.Ptr && srcElement.Kind() != reflect.Ptr {
+				if dstElement.IsNil() {
+					v := reflect.New(dstElement.Type().Elem())
+					dstElement.Set(v)
+				}
+
+				dstElement = dstElement.Elem()
+				dstKind = dstElement.Kind()
+			}
+
 			if !srcElement.IsValid() {
 				continue
 			}

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -761,6 +761,40 @@ func TestBackAndForth(t *testing.T) {
 	}
 }
 
+type typeWithPointerToPrimitiveTypes struct {
+	OptionalString  *string
+	Value           string
+	OptionalInteger *int
+}
+
+func TestNilPointerToField(t *testing.T) {
+	m := map[string]interface{}{
+		"value":           "A required Value",
+		"optionalString":  "An optional value",
+		"optionalInteger": 42,
+	}
+
+	optionalInteger := 35
+
+	pt := typeWithPointerToPrimitiveTypes{OptionalInteger: &optionalInteger}
+
+	if err := mergo.Map(&pt, m); err != nil {
+		t.FailNow()
+	}
+
+	if pt.Value != "A required Value" {
+		t.Errorf("pt not mapped properly: pt.Value(%s) != m[`value`](%s)", pt.Value, m[`value`])
+	}
+
+	if pt.OptionalString == nil || *pt.OptionalString != "An optional value" {
+		t.Errorf("pt not mapped properly: pt.OptionalString(%s) != m[`optionalString`](%s)", *pt.OptionalString, m[`optionalString`])
+	}
+
+	if pt.OptionalInteger == nil || *pt.OptionalInteger != 35 {
+		t.Errorf("pt not mapped properly: pt.OptionalString(%d) != m[`optionalInteger`](%d)", *pt.OptionalInteger, m[`optionalInteger`])
+	}
+}
+
 func TestEmbeddedPointerUnpacking(t *testing.T) {
 	tests := []struct{ input pointerMapTest }{
 		{pointerMapTest{42, 1, nil}},


### PR DESCRIPTION
A common pattern is to use pointer fields as optional values, especially
for structs which are serialized to json, for instance:

```go
type myType struct {
  Value string `json:"value"`
  OptionalValue *int `json:"optionalValue,omitempty"`
}
```

Now we merge the following map to such type:

```go
map[string]interface{} {
  "value": "some value",
  "optionalValue": 42,
}
```

And expect myType.OptionalValue to be allocated and set to `42`.