### PR TITLE
Support pinned tag to protect struct fields from overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,39 @@ func main() {
 }
 ```
 
+### Pin struct fields
+
+You can pin struct fields to protect them from changes in `mergo.WithOverride` mode. Use `mergo:"pinned"` tag for that:
+
+```go
+package main
+
+import (
+	"fmt"
+	"dario.cat/mergo"
+)
+
+type Foo struct {
+	Pinned string `mergo:"pinned"`
+	ToBeChanged string
+}
+
+func main() {
+	dest := Foo{
+		Pinned: "hello",
+		ToBeChanged: "world",
+	}
+	src := Foo{
+		Pinned: "bye",
+		ToBeChanged: "dream",
+	}
+	mergo.Merge(&dest, src, mergo.WithOverride)
+	fmt.Println(dest)
+	// Will print
+	// {hello dream}
+}
+```
+
 ## Contact me
 
 If I can help you, you have an idea or you are using Mergo in your projects, don't hesitate to drop me a line (or a pull request): [@im_dario](https://twitter.com/im_dario)

--- a/issue242_test.go
+++ b/issue242_test.go
@@ -1,0 +1,61 @@
+package mergo_test
+
+import (
+	"reflect"
+	"testing"
+
+	"dario.cat/mergo"
+)
+
+type StudentPinned struct {
+	Name               string     `mergo:"pinned"`
+	Birthplace         Birthplace `mergo:"pinned"`
+	Books              []string
+	IsMemberOfBookClub bool
+}
+
+type Birthplace struct {
+	Country string
+	City    string
+}
+
+func TestMergeWithPinnedFields(t *testing.T) {
+	dst := StudentPinned{
+		Name: "Artur",
+		Birthplace: Birthplace{
+			Country: "Ireland",
+			City:    "Cork",
+		},
+		Books:              []string{"Clean Architecture", "Crime and Punishment"},
+		IsMemberOfBookClub: false,
+	}
+
+	src := StudentPinned{
+		Name: "Changed Name",
+		Birthplace: Birthplace{
+			Country: "Changed",
+			City:    "Birthplace",
+		},
+		Books:              []string{"Mathematical analysis"},
+		IsMemberOfBookClub: true,
+	}
+
+	expected := StudentPinned{
+		Name: "Artur",
+		Birthplace: Birthplace{
+			Country: "Ireland",
+			City:    "Cork",
+		},
+		Books:              []string{"Clean Architecture", "Crime and Punishment", "Mathematical analysis"},
+		IsMemberOfBookClub: true,
+	}
+
+	err := mergo.Merge(&dst, src, mergo.WithOverride, mergo.WithAppendSlice)
+	if err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+
+	if !reflect.DeepEqual(dst, expected) {
+		t.Errorf("expected: %#v\ngot: %#v", expected, dst)
+	}
+}

--- a/merge.go
+++ b/merge.go
@@ -99,10 +99,11 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			for i, n := 0, dst.NumField(); i < n; i++ {
 				field := dst.Type().Field(i)
 				shouldBeSkipped := overwrite && isFieldPinned(&field)
-				if !shouldBeSkipped {
-					if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, config); err != nil {
-						return
-					}
+				if shouldBeSkipped {
+					continue
+				}
+				if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, config); err != nil {
+					return
 				}
 			}
 		} else {


### PR DESCRIPTION
PR for issue https://github.com/darccio/mergo/issues/242.
Adding support of `pinned` tag to protect struct fields from overriding during merge with `mergo.WithOverride` option.
Also adding documentation for the feature to `README.md`.

Test is in `issue242_test.go`