### PR TITLE
fix: `WithoutDereference` should respect non-nil struct pointers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Golang/Intellij
+.idea
+
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 

--- a/issue131_test.go
+++ b/issue131_test.go
@@ -12,6 +12,11 @@ type foz struct {
 	C *bool
 	D *bool
 	E *bool
+	F *baz
+}
+
+type baz struct {
+	A *bool
 }
 
 func TestIssue131MergeWithOverwriteWithEmptyValue(t *testing.T) {
@@ -76,6 +81,9 @@ func TestIssue131MergeWithoutDereference(t *testing.T) {
 		C: nil,
 		D: func(v bool) *bool { return &v }(false),
 		E: func(v bool) *bool { return &v }(true),
+		F: &baz{
+			A: func(v bool) *bool { return &v }(true),
+		},
 	}
 	dest := foz{
 		A: func(v bool) *bool { return &v }(true),
@@ -83,6 +91,7 @@ func TestIssue131MergeWithoutDereference(t *testing.T) {
 		C: func(v bool) *bool { return &v }(false),
 		D: nil,
 		E: func(v bool) *bool { return &v }(false),
+		F: nil,
 	}
 	if err := mergo.Merge(&dest, src, mergo.WithoutDereference); err != nil {
 		t.Error(err)
@@ -100,6 +109,14 @@ func TestIssue131MergeWithoutDereference(t *testing.T) {
 		t.Errorf("dest.D not merged in properly: %v != %v", src.D, *dest.D)
 	}
 	if *dest.E == true {
-		t.Errorf("dest.Eshould not have been merged: %v == %v", *src.E, *dest.E)
+		t.Errorf("dest.E should not have been merged: %v == %v", *src.E, *dest.E)
+	}
+
+	if dest.F == nil {
+		t.Errorf("dest.F should not have be overriden with nil: %v == %v", src.F, dest.F)
+	}
+
+	if *dest.F.A == false {
+		t.Errorf("dest.F.A not merged in properly: %v != %v", *src.F.A, *dest.F.A)
 	}
 }

--- a/merge.go
+++ b/merge.go
@@ -269,7 +269,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 					if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
 						return
 					}
-				} else {
+				} else if src.Elem().Kind() != reflect.Struct {
 					if overwriteWithEmptySrc || (overwrite && !src.IsNil()) || dst.IsNil() {
 						dst.Set(src)
 					}


### PR DESCRIPTION
This PR is a followup to https://github.com/darccio/mergo/issues/131 & https://github.com/darccio/mergo/pull/227.

The changes in this PR address the scenario where a non-nil struct pointer with `WithoutDereference` set will override the entire `dst`. This is unexpected, as a struct does not have a zero value; a non-nil struct should be traversed to determine merge behavior properly.