### PR TITLE
feat(map): Handle json.Number when merging maps

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,36 @@
+package mergo_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"dario.cat/mergo"
+)
+
+func TestJsonNumber(t *testing.T) {
+	jsonSampleData := `
+{
+	"amount": 1234
+}
+`
+
+	type Data struct {
+		Amount int64 `json:"amount"`
+	}
+
+	foo := make(map[string]interface{})
+
+	decoder := json.NewDecoder(bytes.NewReader([]byte(jsonSampleData)))
+	decoder.UseNumber()
+	decoder.Decode(&foo)
+
+	data := Data{}
+	err := mergo.Map(&data, foo)
+	if err != nil {
+		t.Errorf("failed to merge with json.Number: %+v", err)
+	}
+	if data.Amount != 1234 {
+		t.Errorf("merged amount does not match the json value! expected: 1234 got: %v", data.Amount)
+	}
+}


### PR DESCRIPTION
If you unmarshall a json object using the json.Decoder and the UseNumber function, it will create numbers on the map as a `json.Number` object. This object has helper functions for handling ints and floats. So if a json.Number is encountered, try to handle the type of the number based on the destination.

This partially addresses https://github.com/darccio/mergo/issues/138 even though it is an old issue.

If this is not something you'd like to have built in that's totally fine, I'm happy to fork or try to build a transformer for this. But figured a PR would be best since others have asked for it in a way and this seemed like a correct way to do it.