### PR TITLE
chore: setting up for Mergo's next gen implementation

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,30 @@
+package mergo_test
+
+import (
+	"testing"
+
+	"dario.cat/mergo"
+)
+
+func BenchmarkMerge(b *testing.B) {
+	type ts struct {
+		Field string
+	}
+
+	var (
+		dst = ts{}
+		src = ts{
+			Field: "src",
+		}
+	)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := mergo.Merge(&dst, src)
+		if err != nil {
+			b.Fatal(err)
+		}
+		dst.Field = ""
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module dario.cat/mergo
 
-go 1.13
+go 1.18

--- a/internal/ng/README.md
+++ b/internal/ng/README.md
@@ -1,0 +1,10 @@
+# Mergo
+
+## Why next gen?
+
+1. Cleaner code.
+2. Reduce `interface{}`/`any` usage in the API.
+3. Allow the compiler to optimize the code through generics.
+4. Reduce allocations: v1 does 4 allocations per merge.
+5. Reduce `reflect` usage.
+6. Migrate from sentinel errors to [concrete error types](https://jub0bs.com/posts/2025-03-31-why-concrete-error-types-are-superior-to-sentinel-errors/).

--- a/internal/ng/merge.go
+++ b/internal/ng/merge.go
@@ -1,0 +1,138 @@
+package ng
+
+import "reflect"
+
+// Copyright 2025 Dario Castañé. All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Based on src/reflect/deepequal.go from official
+// golang's stdlib.
+
+// Don't use this package. It's a work in progress.
+// This is the next generation of mergo, and it's not ready for production.
+
+type NilArgumentsError struct{}
+
+func (*NilArgumentsError) Error() string {
+	return "src and dst must not be nil"
+}
+
+type InvalidDestinationError struct{}
+
+func (*InvalidDestinationError) Error() string {
+	return "dst must be a pointer"
+}
+
+type DifferentArgumentTypesError struct{}
+
+func (*DifferentArgumentTypesError) Error() string {
+	return "dst and src must have the same type"
+}
+
+// Merge sets any [zero-value](https://go.dev/ref/spec#The_zero_value) field
+// in dst with the same field's value in src.
+// Both dst and src must have the same type, being dst a pointer to the type.
+// Merge returns NilArgumentsError if dst is a nil pointer and/or src is a nil
+// value.
+// If dst and src are values of predefined types, and dst is the type's zero
+// value, src is assigned to dst.
+// Merge is a convenient wrapper around the more compiler-friendly MergeValue
+// and MergePtr functions.
+func Merge(dst, src any) error {
+	if dst == nil {
+		// As dst pointer is a copy; assigning src to a nil pointer is an
+		// ineffective assignment.
+		return new(NilArgumentsError)
+	}
+
+	if src == nil {
+		// Nothing to do here.
+		return new(NilArgumentsError)
+	}
+
+	dstValue := reflect.ValueOf(dst)
+	if dstValue.Kind() != reflect.Ptr {
+		return new(InvalidDestinationError)
+	}
+
+	dstValue = dstValue.Elem()
+	srcValue := reflect.ValueOf(src)
+
+	if srcValue.Kind() == reflect.Ptr {
+		srcValue = srcValue.Elem()
+	}
+
+	if dstValue.Type() != srcValue.Type() {
+		return new(DifferentArgumentTypesError)
+	}
+
+	merge(dstValue, srcValue, dstValue.Type())
+
+	return nil
+}
+
+func MergeValue[T any](dst *T, src T) error {
+	if dst == nil {
+		// As dst pointer is a copy; assigning src to a nil pointer is an
+		// ineffective assignment.
+		return new(NilArgumentsError)
+	}
+
+	dstValue := reflect.ValueOf(dst).Elem()
+	srcValue := reflect.ValueOf(src)
+
+	merge(dstValue, srcValue, dstValue.Type())
+
+	return nil
+}
+
+func MergePtr[T any](dst, src *T) error {
+	if dst == nil {
+		// As dst pointer is a copy; assigning src to a nil pointer is an
+		// ineffective assignment.
+		return new(NilArgumentsError)
+	}
+
+	if src == nil {
+		// Nothing to do here.
+		return new(NilArgumentsError)
+	}
+
+	dstValue := reflect.ValueOf(dst).Elem()
+	srcValue := reflect.ValueOf(src).Elem()
+
+	merge(dstValue, srcValue, dstValue.Type())
+
+	return nil
+}
+
+func merge(dst, src reflect.Value, typ reflect.Type) {
+	if typ.Kind() == reflect.Struct {
+		mergeStruct(dst, src, typ)
+	}
+
+	// TODO: handle maps and slices
+	// TODO: handle pointers and interfaces
+	// TODO: cover all potential empty cases (as in isEmptyValue from v1)
+	if !dst.IsZero() {
+		return
+	}
+
+	dst.Set(src)
+}
+
+func mergeStruct(dst, src reflect.Value, typ reflect.Type) {
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		dstField := dst.Field(i)
+		srcField := src.Field(i)
+
+		if !dstField.CanSet() {
+			continue
+		}
+
+		merge(dstField, srcField, field.Type)
+	}
+}

--- a/internal/ng/merge_test.go
+++ b/internal/ng/merge_test.go
@@ -1,0 +1,374 @@
+package ng_test
+
+import (
+	"errors"
+	"testing"
+
+	mergo "dario.cat/mergo/internal/ng"
+)
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	type ts struct {
+		Field int
+	}
+
+	t.Run("merge", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dst = ts{
+				Field: 0,
+			}
+			src = ts{
+				Field: 1,
+			}
+		)
+
+		if err := mergo.Merge(&dst, src); err != nil {
+			t.Errorf("Error while merging %s", err)
+		}
+
+		if dst.Field != src.Field {
+			t.Errorf("Expected dst.Field to be %d, got %d", src.Field, dst.Field)
+		}
+	})
+
+	t.Run("merge from pointer", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dst = &ts{
+				Field: 0,
+			}
+			src = &ts{
+				Field: 1,
+			}
+		)
+
+		if err := mergo.Merge(dst, src); err != nil {
+			t.Errorf("Error while merging %s", err)
+		}
+
+		if dst.Field != src.Field {
+			t.Errorf("Expected dst.Field to be %d, got %d", src.Field, dst.Field)
+		}
+	})
+}
+
+func TestMergePredefinedType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merge ints", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dst = 0
+			src = 1
+		)
+
+		if err := mergo.Merge(&dst, src); err != nil {
+			t.Errorf("Error while merging %s", err)
+		}
+
+		if dst != src {
+			t.Errorf("Expected dst to be %d, got %d", src, dst)
+		}
+	})
+
+	t.Run("merge strings", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dst = ""
+			src = "src"
+		)
+
+		if err := mergo.Merge(&dst, src); err != nil {
+			t.Errorf("Error while merging %s", err)
+		}
+
+		if dst != src {
+			t.Errorf("Expected dst to be %q, got %q", src, dst)
+		}
+	})
+}
+
+func TestMergeNil(t *testing.T) {
+	t.Parallel()
+
+	t.Run("both nil", func(t *testing.T) {
+		t.Parallel()
+
+		var naerr *mergo.NilArgumentsError
+
+		if err := mergo.Merge(nil, nil); !errors.As(err, &naerr) {
+			t.Error(err)
+		}
+	})
+
+	t.Run("dst nil", func(t *testing.T) {
+		t.Parallel()
+
+		var naerr *mergo.NilArgumentsError
+
+		if err := mergo.Merge(nil, struct{}{}); !errors.As(err, &naerr) {
+			t.Error(err)
+		}
+	})
+
+	t.Run("src nil", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dst   = struct{}{}
+			naerr *mergo.NilArgumentsError
+		)
+
+		if err := mergo.Merge(&dst, nil); !errors.As(err, &naerr) {
+			t.Error(err)
+		}
+	})
+}
+
+func TestMergeNotZero(t *testing.T) {
+	t.Parallel()
+
+	type ts struct {
+		Field int
+	}
+
+	var (
+		dst = ts{
+			Field: 1,
+		}
+		src = ts{
+			Field: 2,
+		}
+	)
+
+	if err := mergo.Merge(&dst, src); err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+
+	if dst.Field == src.Field {
+		t.Errorf("Expected dst.Field to be 1, got %d", dst.Field)
+	}
+}
+
+func TestMergeOnlyExportedFields(t *testing.T) {
+	t.Parallel()
+
+	type ts struct {
+		Field      int
+		unexported int
+	}
+
+	var (
+		dst = ts{
+			Field:      0,
+			unexported: 2,
+		}
+		src = ts{
+			Field:      3,
+			unexported: 4,
+		}
+	)
+
+	if err := mergo.Merge(&dst, src); err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+
+	if dst.Field != src.Field {
+		t.Errorf("Expected dst.Field to be %d, got %d", src.Field, dst.Field)
+	}
+
+	if dst.unexported == src.unexported {
+		t.Errorf("Expected dst.unexported to be 2, got %d", dst.unexported)
+	}
+}
+
+func TestMergeNotPointer(t *testing.T) {
+	t.Parallel()
+
+	var npeerr *mergo.InvalidDestinationError
+	if err := mergo.Merge(struct{}{}, struct{}{}); !errors.As(err, &npeerr) {
+		t.Error(err)
+	}
+}
+
+func TestMergeDifferentTypes(t *testing.T) {
+	t.Parallel()
+
+	dst := struct {
+		Field int
+	}{
+		Field: 1,
+	}
+
+	src := struct {
+		Field string
+	}{
+		Field: "src",
+	}
+
+	var dteerr *mergo.DifferentArgumentTypesError
+	if err := mergo.Merge(&dst, src); !errors.As(err, &dteerr) {
+		t.Error(err)
+	}
+}
+
+func TestMergeValue(t *testing.T) {
+	t.Parallel()
+
+	type ts struct {
+		Field int
+	}
+
+	dst := ts{
+		Field: 0,
+	}
+
+	src := ts{
+		Field: 1,
+	}
+
+	if err := mergo.MergeValue(&dst, src); err != nil {
+		t.Error(err)
+	}
+
+	if dst.Field != src.Field {
+		t.Errorf("Expected dst.Field to be %d, got %d", src.Field, dst.Field)
+	}
+}
+
+func TestMergeValueNil(t *testing.T) {
+	t.Parallel()
+
+	var naerr *mergo.NilArgumentsError
+
+	if err := mergo.MergeValue(nil, struct{}{}); !errors.As(err, &naerr) {
+		t.Error(err)
+	}
+}
+
+func TestMergePtr(t *testing.T) {
+	t.Parallel()
+
+	type ts struct {
+		Field int
+	}
+
+	var (
+		dst = &ts{
+			Field: 0,
+		}
+		src = &ts{
+			Field: 1,
+		}
+	)
+
+	if err := mergo.MergePtr(dst, src); err != nil {
+		t.Error(err)
+	}
+
+	if dst.Field != src.Field {
+		t.Errorf("Expected dst.Field to be %d, got %d", src.Field, dst.Field)
+	}
+}
+
+func TestMergePtrNil(t *testing.T) {
+	t.Parallel()
+
+	type ts struct {
+		Field int
+	}
+
+	t.Run("dst nil", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			src = &ts{
+				Field: 0,
+			}
+			naerr *mergo.NilArgumentsError
+		)
+
+		if err := mergo.MergePtr(nil, src); !errors.As(err, &naerr) {
+			t.Error(err)
+		}
+	})
+
+	t.Run("src nil", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dst = &ts{
+				Field: 0,
+			}
+			naerr *mergo.NilArgumentsError
+		)
+
+		if err := mergo.MergePtr(dst, nil); !errors.As(err, &naerr) {
+			t.Error(err)
+		}
+	})
+
+	t.Run("both nil", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dst   *ts
+			src   *ts
+			naerr *mergo.NilArgumentsError
+		)
+
+		if err := mergo.MergePtr(dst, src); !errors.As(err, &naerr) {
+			t.Error(err)
+		}
+	})
+}
+
+func TestErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NilArgumentsError", func(t *testing.T) {
+		t.Parallel()
+
+		msg := "src and dst must not be nil"
+		if err := mergo.Merge(nil, nil); err.Error() != msg {
+			t.Errorf("Expected error to be %q, got %q", msg, err.Error())
+		}
+	})
+
+	t.Run("InvalidDestinationError", func(t *testing.T) {
+		t.Parallel()
+
+		msg := "dst must be a pointer"
+		if err := mergo.Merge(struct{}{}, struct{}{}); err.Error() != msg {
+			t.Errorf("Expected error to be %q, got %q", msg, err.Error())
+		}
+	})
+
+	t.Run("DifferentArgumentTypesError", func(t *testing.T) {
+		t.Parallel()
+
+		dst := struct {
+			Field int
+		}{
+			Field: 1,
+		}
+
+		src := struct {
+			Field string
+		}{
+			Field: "src",
+		}
+
+		msg := "dst and src must have the same type"
+		if err := mergo.Merge(&dst, src); err.Error() != msg {
+			t.Errorf("Expected error to be %q, got %q", msg, err.Error())
+		}
+	})
+}

--- a/internal/ng/merge_test.go
+++ b/internal/ng/merge_test.go
@@ -372,3 +372,63 @@ func TestErrorMessages(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkMerge(b *testing.B) {
+	b.ReportAllocs()
+
+	type ts struct {
+		Field int
+	}
+
+	src := ts{
+		Field: 2,
+	}
+
+	b.Run("Merge", func(b *testing.B) {
+		dst := ts{
+			Field: 0,
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			if err := mergo.Merge(&dst, src); err != nil {
+				b.Fatal(err)
+			}
+
+			dst.Field = 0
+		}
+	})
+
+	b.Run("MergeValue", func(b *testing.B) {
+		dst := ts{
+			Field: 0,
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			if err := mergo.MergeValue(&dst, src); err != nil {
+				b.Fatal(err)
+			}
+
+			dst.Field = 0
+		}
+	})
+
+	b.Run("MergePtr", func(b *testing.B) {
+		dst := &ts{
+			Field: 0,
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			if err := mergo.MergePtr(dst, &src); err != nil {
+				b.Fatal(err)
+			}
+
+			dst.Field = 0
+		}
+	})
+}

--- a/merge.go
+++ b/merge.go
@@ -376,7 +376,7 @@ func merge(dst, src interface{}, opts ...func(*Config)) error {
 		err        error
 	)
 
-	config := &Config{}
+	config := &Config{} // First allocation
 
 	for _, opt := range opts {
 		opt(config)

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -86,9 +86,22 @@ func TestKb(t *testing.T) {
 }
 
 func TestNil(t *testing.T) {
-	if err := mergo.Merge(nil, nil); err != mergo.ErrNilArguments {
-		t.Fail()
-	}
+	t.Run("both nil", func(t *testing.T) {
+		if err := mergo.Merge(nil, nil); err != mergo.ErrNilArguments {
+			t.Fail()
+		}
+	})
+	t.Run("dst nil", func(t *testing.T) {
+		if err := mergo.Merge(nil, struct{}{}); err != mergo.ErrNilArguments {
+			t.Fail()
+		}
+	})
+	t.Run("src nil", func(t *testing.T) {
+		dst := struct{}{}
+		if err := mergo.Merge(&dst, nil); err != mergo.ErrNilArguments {
+			t.Error(err)
+		}
+	})
 }
 
 func TestDifferentTypes(t *testing.T) {


### PR DESCRIPTION
- Updated Go version in go.mod from 1.13 to 1.18.
- Initial new implementation from scratch, with full coverage.
- New API for more compiler-friendliness.
- Migration from sentinel errors to concrete error types.