### PR TITLE
test: cover reflect.Func branch in isEmptyValue

### DIFF
--- a/mergo_test.go
+++ b/mergo_test.go
@@ -953,3 +953,35 @@ func TestMergeDifferentSlicesIsNotSupported(t *testing.T) {
 		t.Errorf("expected %q, got %q", mergo.ErrNotSupported, err)
 	}
 }
+
+func TestMergeFuncField(t *testing.T) {
+	// isEmptyValue has a reflect.Func case that returns v.IsNil(). It is only
+	// exercised when a struct field has a function type. This test covers both
+	// the nil-func (empty → should be filled) and non-nil-func (non-empty →
+	// should not be overwritten without WithOverride) paths.
+	type withFunc struct {
+		F func() string
+	}
+
+	fn := func() string { return "src" }
+
+	// nil dst.F should be filled from a non-nil src.F
+	dst := withFunc{}
+	src := withFunc{F: fn}
+	if err := mergo.Merge(&dst, src); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dst.F == nil {
+		t.Error("expected dst.F to be set from src, got nil")
+	}
+
+	// non-nil dst.F should not be overwritten without WithOverride
+	existing := func() string { return "dst" }
+	dst2 := withFunc{F: existing}
+	if err := mergo.Merge(&dst2, src); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dst2.F() != "dst" {
+		t.Errorf("expected dst2.F to remain unchanged, got %q", dst2.F())
+	}
+}


### PR DESCRIPTION
Closes #303 (first checklist item).

## What

Adds `TestMergeFuncField` to cover the `case reflect.Func: return v.IsNil()` branch in `isEmptyValue` (`mergo.go:57–58`), which was previously unreachable by any test.

## Why

No existing test used a struct with a function-typed field, so mergo's behaviour when merging such fields was unverified. The branch determines whether a `func` field is considered empty (nil) or not, which controls whether the value is copied from src.

## Test cases

- `dst.F == nil` → filled from `src.F` (nil func is empty)
- `dst.F != nil` → not overwritten without `WithOverride` (non-nil func is non-empty)

## Coverage delta

| | Before | After |
|---|---|---|
| `isEmptyValue` | 85.7% | 92.9% |
| overall | 85.4% | 85.7% |