### PR TITLE
Support struct tags for map keys

### DIFF
--- a/issue255_test.go
+++ b/issue255_test.go
@@ -1,0 +1,41 @@
+package mergo_test
+
+import (
+	"testing"
+
+	"dario.cat/mergo"
+)
+
+type issue255Person struct {
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name,omitempty"`
+	Password  string `json:"-"`
+	Age       int
+}
+
+func TestIssue255MapStructToMapWithTaggedKeys(t *testing.T) {
+	person := issue255Person{
+		FirstName: "Ada",
+		LastName:  "Lovelace",
+		Password:  "secret",
+		Age:       36,
+	}
+
+	actual := map[string]interface{}{}
+	if err := mergo.Map(&actual, person, mergo.WithMapKeyTag("json")); err != nil {
+		t.Fatal(err)
+	}
+
+	if actual["first_name"] != "Ada" {
+		t.Fatalf("expected first_name key to be mapped from tag, got %#v", actual)
+	}
+	if actual["last_name"] != "Lovelace" {
+		t.Fatalf("expected tag name to be used, got %#v", actual)
+	}
+	if actual["password"] != "secret" {
+		t.Fatalf("expected '-' tag to fall back to default field name, got %#v", actual)
+	}
+	if actual["age"] != 36 {
+		t.Fatalf("expected untagged field to fall back to default field name, got %#v", actual)
+	}
+}

--- a/map.go
+++ b/map.go
@@ -11,6 +11,7 @@ package mergo
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -58,6 +59,14 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, conf
 			}
 			fieldName := field.Name
 			fieldName = changeInitialCase(fieldName, unicode.ToLower)
+			if config.mapKeyTag != "" {
+				if taggedName := field.Tag.Get(config.mapKeyTag); taggedName != "" {
+					taggedName, _, _ = strings.Cut(taggedName, ",")
+					if taggedName != "" && taggedName != "-" {
+						fieldName = taggedName
+					}
+				}
+			}
 			if _, ok := dstMap[fieldName]; !ok || (!isEmptyValue(reflect.ValueOf(src.Field(i).Interface()), !config.ShouldNotDereference) && overwrite) || config.overwriteWithEmptyValue {
 				dstMap[fieldName] = src.Field(i).Interface()
 			}

--- a/merge.go
+++ b/merge.go
@@ -46,6 +46,7 @@ type Config struct {
 	overwriteWithEmptyValue      bool
 	overwriteSliceWithEmptyValue bool
 	sliceDeepCopy                bool
+	mapKeyTag                    string
 }
 
 type Transformers interface {
@@ -365,6 +366,13 @@ func WithTypeCheck(config *Config) {
 func WithSliceDeepCopy(config *Config) {
 	config.sliceDeepCopy = true
 	config.Overwrite = true
+}
+
+// WithMapKeyTag uses the named struct tag value as the destination map key when mapping a struct to map.
+func WithMapKeyTag(tag string) func(*Config) {
+	return func(config *Config) {
+		config.mapKeyTag = tag
+	}
 }
 
 func merge(dst, src interface{}, opts ...func(*Config)) error {


### PR DESCRIPTION
/claim #255

## Summary
- Adds `WithMapKeyTag(tag)` for struct-to-map mapping.
- Uses the named struct tag value as the destination map key, including stripping comma options like `json:"name,omitempty"`.
- Falls back to the existing lower-camel field name when the tag is missing, empty, or `-`.
- Adds regression coverage for tagged, untagged, and ignored-tag fields.

## Validation
- `go test ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to use custom struct tags (e.g., JSON tags) as destination map keys when mapping structs to maps. Users can now specify their preferred tag for key derivation during struct-to-map conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->